### PR TITLE
Release v0.0.1-alpha.20250907

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,7 @@
+# Changelog
+
+## [0.0.1-alpha.20250907] - 2025-09-07
+
+* First alpha release with basic RAW editing, GPU acceleration (Linux).
+* Includes exposure, white balance, tone curves, and crop tools.
+* Linux and macOS supported

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,7 +16,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 # https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 # In Windows, build-name is used as the major, minor, and patch parts
 # of the product and file versions while build-number is used as the build suffix.
-version: 0.0.1+1
+version: 0.0.1-alpha.20250907+1
 
 environment:
   sdk: ^3.9.0


### PR DESCRIPTION
## Release v0.0.1-alpha.20250907

First alpha release of aks.

### Changes
- Version bump to 0.0.1-alpha.20250907
- Added CHANGELOG.md

### Release
- GitHub release created: https://github.com/myyc/aks/releases/tag/v0.0.1-alpha.20250907
- Flatpak bundle included

🤖 Generated with [Claude Code](https://claude.ai/code)